### PR TITLE
docs: dynamically render Mermaid diagrams on GitHub Pages

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,1 +1,2 @@
 theme: jekyll-theme-leap-day
+markdown: kramdown

--- a/docs/_includes/head-custom.html
+++ b/docs/_includes/head-custom.html
@@ -1,0 +1,17 @@
+<script type="module">
+  import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs';
+  mermaid.initialize({ startOnLoad: false });
+  document.addEventListener("DOMContentLoaded", async function() {
+    const elements = document.querySelectorAll('.language-mermaid');
+    elements.forEach(el => {
+      const codeBlock = el.querySelector('code');
+      if (codeBlock) {
+        el.textContent = codeBlock.textContent;
+        el.classList.add('mermaid');
+      }
+    });
+    await mermaid.run({
+      querySelector: '.mermaid'
+    });
+  });
+</script>


### PR DESCRIPTION
This PR fixes the rendering of Mermaid diagrams on GitHub Pages. Since standard GitHub Pages restrict the use of third-party Jekyll plugins to render Mermaid diagrams during the build phase, this introduces a lightweight client-side solution.

The implementation relies on the fact that standard `jekyll-theme-leap-day` allows injecting custom HTML headers via `docs/_includes/head-custom.html`. It dynamically loads the Mermaid ESM module via a CDN, detects Jekyll-generated `.language-mermaid` code blocks, properly unescapes the code snippet, and then instructs Mermaid to render them on the fly. This keeps the markdown clean and standard, requiring zero dependencies or manual `.mermaid` tag wrapping.

---
*PR created automatically by Jules for task [14570960433883998734](https://jules.google.com/task/14570960433883998734) started by @lostcontrol*